### PR TITLE
Fix build on nightly

### DIFF
--- a/src/nightly.rs
+++ b/src/nightly.rs
@@ -10,6 +10,7 @@ use core::ops;
 use core::num::Wrapping;
 use core::sync::atomic::{AtomicU8, AtomicU16, AtomicU32, AtomicU64, Ordering};
 
+#[path = "fallback.rs"]
 mod fallback;
 
 #[inline]

--- a/src/stable.rs
+++ b/src/stable.rs
@@ -10,6 +10,7 @@ use core::ops;
 use core::num::Wrapping;
 use core::sync::atomic::{Ordering, AtomicUsize};
 
+#[path = "fallback.rs"]
 mod fallback;
 
 #[inline]


### PR DESCRIPTION
Hi, @Amanieu.

https://github.com/rust-lang/rust/pull/42894 makes some compatibility lints in `rustc` deny-by-default and regression testing found that this crate is affected. Here's a patch fixing the deprecated code (see https://github.com/rust-lang/rust/issues/37872 for more information about the issue).