### PR TITLE
Fix compile error when nightly feature is enabled

### DIFF
--- a/src/ops.rs
+++ b/src/ops.rs
@@ -28,7 +28,8 @@ const ALIGNOF_USIZE: usize = mem::align_of::<usize>();
 #[inline]
 pub const fn atomic_is_lock_free<T>() -> bool {
     let size = mem::size_of::<T>();
-    1 == size.count_ones() && 8 >= size && mem::align_of::<T>() >= size
+    // FIXME: switch to … && … && … once that operator is supported in const functions
+    (1 == size.count_ones()) & (8 >= size) & (mem::align_of::<T>() >= size)
 }
 
 #[cfg(not(feature = "nightly"))]


### PR DESCRIPTION
Stop using the && operator in const functions. It not yet allowed there.

The error:

```
$ cargo +nightly build --features nightly
   Compiling atomic v0.4.1 (/home/user/src/atomic-rs)
error[E0019]: constant function contains unimplemented expression type
  --> src/ops.rs:31:5
   |
31 |     1 == size.count_ones() && 8 >= size && mem::align_of::<T>() >= size
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```