### PR TITLE
update for latest nightly that changes integer_atomics

### DIFF
--- a/src/fallback.rs
+++ b/src/fallback.rs
@@ -11,7 +11,7 @@ use core::num::Wrapping;
 use core::ops;
 use core::ptr;
 use core::slice;
-use core::sync::atomic::{self, AtomicUsize, Ordering, ATOMIC_USIZE_INIT};
+use core::sync::atomic::{self, AtomicUsize, Ordering};
 
 // We use an AtomicUsize instead of an AtomicBool because it performs better
 // on architectures that don't have byte-sized atomics.
@@ -63,7 +63,7 @@ macro_rules! array {
 
     [$e:expr; $n:tt] => { array!(@accum ($n, $e) -> ()) };
 }
-static SPINLOCKS: [SpinLock; 64] = array![SpinLock(ATOMIC_USIZE_INIT); 64];
+static SPINLOCKS: [SpinLock; 64] = array![SpinLock(AtomicUsize::new(0)); 64];
 
 // Spinlock pointer hashing function from compiler-rt
 #[inline]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,7 +33,7 @@
 #![warn(missing_docs)]
 #![no_std]
 #![cfg_attr(
-    feature = "nightly", feature(const_fn, cfg_target_has_atomic, integer_atomics, atomic_min_max)
+    feature = "nightly", feature(const_fn, cfg_target_has_atomic, atomic_min_max)
 )]
 
 #[cfg(test)]


### PR DESCRIPTION
Looks like integer_atomics was stabilized, and the feature was removed. Also, there is a newly-preferred way of initializing an atomic integer, so I changed it to that. 