### PR TITLE
Replace use of unstable features by use of autocfg

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ rust:
 - nightly
 - beta
 - stable
-- 1.31.0
+- 1.45.0
 
 before_script:
 - |

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ rust:
 - nightly
 - beta
 - stable
-- 1.26.0
+- 1.31.0
 
 before_script:
 - |
@@ -15,14 +15,14 @@ before_script:
 script:
 - travis-cargo build
 - travis-cargo test
-- travis-cargo doc
+- travis-cargo --only stable doc
 
 after_success:
-- travis-cargo --only nightly doc-upload
+- travis-cargo --only stable doc-upload
 
 env:
   global:
-  - TRAVIS_CARGO_NIGHTLY_FEATURE=nightly
+  - TRAVIS_CARGO_NIGHTLY_FEATURE=
 
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,22 +7,12 @@ rust:
 - stable
 - 1.45.0
 
-before_script:
-- |
-  pip install 'travis-cargo<0.2' --user &&
-  export PATH=$HOME/.local/bin:$PATH
-
 script:
-- travis-cargo build
-- travis-cargo test
-- travis-cargo --only stable doc
-
-after_success:
-- travis-cargo --only stable doc-upload
-
-env:
-  global:
-  - TRAVIS_CARGO_NIGHTLY_FEATURE=
+- cargo build
+- cargo test
+- cargo doc
+- if [ $TRAVIS_RUST_VERSION = nightly ]; then rustup target add aarch64-unknown-none; fi
+- if [ $TRAVIS_RUST_VERSION = nightly ]; then RUSTFLAGS="-Zcrate-attr=feature(integer_atomics)" cargo check --target=aarch64-unknown-none; fi
 
 notifications:
   email: false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,5 +10,7 @@ readme = "README.md"
 keywords = ["atomic", "no_std"]
 
 [features]
-nightly = []
 std = []
+
+[build-dependencies]
+autocfg = "1"

--- a/README.md
+++ b/README.md
@@ -7,8 +7,6 @@ A Rust library which provides a generic `Atomic<T>` type for all `T: Copy` types
 
 This library will use native atomic instructions if possible, and will otherwise fall back to a lock-based mechanism. You can use the `Atomic::<T>::is_lock_free()` function to check whether native atomic operations are supported for a given type. Note that a type must have a power-of-2 size and alignment in order to be used by native atomic instructions.
 
-Only a subset of native atomic operations are supported on stable Rust (types which are the same size as `AtomicUsize`), but you can use the `nightly` Cargo feature on a nightly compiler to enable the full range of native atomic instructions. The `nightly` feature also enables `const fn` constructors which allow you to initialize static atomic variables.
-
 This crate uses `#![no_std]` and only depends on libcore.
 
 [Documentation](https://amanieu.github.io/atomic-rs/atomic/index.html)

--- a/build.rs
+++ b/build.rs
@@ -4,7 +4,7 @@ fn main() {
     let ac = autocfg::new();
 
     for root in &["core", "std"] {
-        for size in &[8, 16, 32, 64] {
+        for size in &[8, 16, 32, 64, 128] {
             ac.emit_expression_cfg(
                 &format!("{}::sync::atomic::AtomicU{}::compare_exchange", root, size),
                 &format!("has_atomic_u{}", size),

--- a/build.rs
+++ b/build.rs
@@ -23,10 +23,5 @@ fn main() {
                 &format!("has_atomic_i{}", size),
             );
         }
-
-        ac.emit_expression_cfg(
-            &format!("{}::sync::atomic::AtomicUsize::fetch_min", root),
-            "has_fetch_min",
-        );
     }
 }

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,32 @@
+extern crate autocfg;
+
+fn main() {
+    let ac = autocfg::new();
+
+    for root in &["core", "std"] {
+        ac.emit_path_cfg(
+            &format!("{}::sync::atomic::AtomicUsize", root),
+            "has_atomic_usize",
+        );
+        ac.emit_path_cfg(
+            &format!("{}::sync::atomic::AtomicIsize", root),
+            "has_atomic_isize",
+        );
+
+        for size in &[8, 16, 32, 64] {
+            ac.emit_path_cfg(
+                &format!("{}::sync::atomic::AtomicU{}", root, size),
+                &format!("has_atomic_u{}", size),
+            );
+            ac.emit_path_cfg(
+                &format!("{}::sync::atomic::AtomicI{}", root, size),
+                &format!("has_atomic_i{}", size),
+            );
+        }
+
+        ac.emit_expression_cfg(
+            &format!("{}::sync::atomic::AtomicUsize::fetch_min", root),
+            "has_fetch_min",
+        );
+    }
+}

--- a/build.rs
+++ b/build.rs
@@ -4,22 +4,13 @@ fn main() {
     let ac = autocfg::new();
 
     for root in &["core", "std"] {
-        ac.emit_path_cfg(
-            &format!("{}::sync::atomic::AtomicUsize", root),
-            "has_atomic_usize",
-        );
-        ac.emit_path_cfg(
-            &format!("{}::sync::atomic::AtomicIsize", root),
-            "has_atomic_isize",
-        );
-
         for size in &[8, 16, 32, 64] {
-            ac.emit_path_cfg(
-                &format!("{}::sync::atomic::AtomicU{}", root, size),
+            ac.emit_expression_cfg(
+                &format!("{}::sync::atomic::AtomicU{}::compare_exchange", root, size),
                 &format!("has_atomic_u{}", size),
             );
-            ac.emit_path_cfg(
-                &format!("{}::sync::atomic::AtomicI{}", root, size),
+            ac.emit_expression_cfg(
+                &format!("{}::sync::atomic::AtomicI{}::compare_exchange", root, size),
                 &format!("has_atomic_i{}", size),
             );
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,9 +32,6 @@
 
 #![warn(missing_docs)]
 #![no_std]
-#![cfg_attr(
-    feature = "nightly", feature(const_fn, cfg_target_has_atomic, atomic_min_max)
-)]
 
 #[cfg(any(test, feature = "std"))]
 #[macro_use]
@@ -54,7 +51,7 @@ mod ops;
 
 /// A generic atomic wrapper type which allows an object to be safely shared
 /// between threads.
-pub struct Atomic<T: Copy> {
+pub struct Atomic<T> {
     v: UnsafeCell<T>,
 }
 
@@ -85,47 +82,27 @@ impl<T: Copy + fmt::Debug> fmt::Debug for Atomic<T> {
     }
 }
 
-impl<T: Copy> Atomic<T> {
+impl<T> Atomic<T> {
     /// Creates a new `Atomic`.
     #[inline]
-    #[cfg(feature = "nightly")]
     pub const fn new(v: T) -> Atomic<T> {
         Atomic {
             v: UnsafeCell::new(v),
         }
     }
 
-    /// Creates a new `Atomic`.
-    #[inline]
-    #[cfg(not(feature = "nightly"))]
-    pub fn new(v: T) -> Atomic<T> {
-        Atomic {
-            v: UnsafeCell::new(v),
-        }
-    }
-
     /// Checks if `Atomic` objects of this type are lock-free.
     ///
     /// If an `Atomic` is not lock-free then it may be implemented using locks
     /// internally, which makes it unsuitable for some situations (such as
     /// communicating with a signal handler).
     #[inline]
-    #[cfg(feature = "nightly")]
     pub const fn is_lock_free() -> bool {
         ops::atomic_is_lock_free::<T>()
     }
+}
 
-    /// Checks if `Atomic` objects of this type are lock-free.
-    ///
-    /// If an `Atomic` is not lock-free then it may be implemented using locks
-    /// internally, which makes it unsuitable for some situations (such as
-    /// communicating with a signal handler).
-    #[inline]
-    #[cfg(not(feature = "nightly"))]
-    pub fn is_lock_free() -> bool {
-        ops::atomic_is_lock_free::<T>()
-    }
-
+impl<T: Copy> Atomic<T> {
     /// Returns a mutable reference to the underlying type.
     ///
     /// This is safe because the mutable reference guarantees that no other threads are
@@ -396,8 +373,8 @@ macro_rules! atomic_ops_unsigned {
         )*
     );
 }
-atomic_ops_signed!{ i8 i16 i32 i64 isize i128 }
-atomic_ops_unsigned!{ u8 u16 u32 u64 usize u128 }
+atomic_ops_signed! { i8 i16 i32 i64 isize i128 }
+atomic_ops_unsigned! { u8 u16 u32 u64 usize u128 }
 
 #[cfg(test)]
 mod tests {
@@ -415,7 +392,13 @@ mod tests {
     #[test]
     fn atomic_bool() {
         let a = Atomic::new(false);
-        assert_eq!(Atomic::<bool>::is_lock_free(), cfg!(feature = "nightly"));
+        assert_eq!(
+            Atomic::<bool>::is_lock_free(),
+            cfg!(any(
+                has_atomic_u8,
+                all(target_pointer_width = "8", has_atomic_usize)
+            ))
+        );
         assert_eq!(format!("{:?}", a), "Atomic(false)");
         assert_eq!(a.load(SeqCst), false);
         a.store(true, SeqCst);
@@ -434,8 +417,8 @@ mod tests {
         assert_eq!(
             Atomic::<i8>::is_lock_free(),
             cfg!(any(
-                target_pointer_width = "8",
-                all(feature = "nightly", target_has_atomic = "8")
+                has_atomic_u8,
+                all(target_pointer_width = "8", has_atomic_usize)
             ))
         );
         assert_eq!(format!("{:?}", a), "Atomic(0)");
@@ -461,8 +444,8 @@ mod tests {
         assert_eq!(
             Atomic::<i16>::is_lock_free(),
             cfg!(any(
-                target_pointer_width = "16",
-                all(feature = "nightly", target_has_atomic = "16")
+                has_atomic_u16,
+                all(target_pointer_width = "16", has_atomic_usize)
             ))
         );
         assert_eq!(format!("{:?}", a), "Atomic(0)");
@@ -487,8 +470,8 @@ mod tests {
         assert_eq!(
             Atomic::<i32>::is_lock_free(),
             cfg!(any(
-                target_pointer_width = "32",
-                all(feature = "nightly", target_has_atomic = "32")
+                has_atomic_u32,
+                all(target_pointer_width = "32", has_atomic_usize)
             ))
         );
         assert_eq!(format!("{:?}", a), "Atomic(0)");
@@ -513,8 +496,8 @@ mod tests {
         assert_eq!(
             Atomic::<i64>::is_lock_free(),
             cfg!(any(
-                target_pointer_width = "64",
-                all(feature = "nightly", target_has_atomic = "64")
+                has_atomic_u64,
+                all(target_pointer_width = "64", has_atomic_usize)
             )) && mem::align_of::<i64>() == 8
         );
         assert_eq!(format!("{:?}", a), "Atomic(0)");
@@ -538,10 +521,7 @@ mod tests {
         let a = Atomic::new(0i128);
         assert_eq!(
             Atomic::<i128>::is_lock_free(),
-            cfg!(any(
-                target_pointer_width = "128",
-                all(feature = "nightly", target_has_atomic = "128")
-            ))
+            cfg!(all(target_pointer_width = "128", has_atomic_usize))
         );
         assert_eq!(format!("{:?}", a), "Atomic(0)");
         assert_eq!(a.load(SeqCst), 0);
@@ -562,7 +542,7 @@ mod tests {
     #[test]
     fn atomic_isize() {
         let a = Atomic::new(0isize);
-        assert!(Atomic::<isize>::is_lock_free());
+        assert_eq!(Atomic::<isize>::is_lock_free(), cfg!(has_atomic_usize));
         assert_eq!(format!("{:?}", a), "Atomic(0)");
         assert_eq!(a.load(SeqCst), 0);
         a.store(1, SeqCst);
@@ -585,8 +565,8 @@ mod tests {
         assert_eq!(
             Atomic::<u8>::is_lock_free(),
             cfg!(any(
-                target_pointer_width = "8",
-                all(feature = "nightly", target_has_atomic = "8")
+                has_atomic_u8,
+                all(target_pointer_width = "8", has_atomic_usize)
             ))
         );
         assert_eq!(format!("{:?}", a), "Atomic(0)");
@@ -611,8 +591,8 @@ mod tests {
         assert_eq!(
             Atomic::<u16>::is_lock_free(),
             cfg!(any(
-                target_pointer_width = "16",
-                all(feature = "nightly", target_has_atomic = "16")
+                has_atomic_u16,
+                all(target_pointer_width = "16", has_atomic_usize)
             ))
         );
         assert_eq!(format!("{:?}", a), "Atomic(0)");
@@ -637,8 +617,8 @@ mod tests {
         assert_eq!(
             Atomic::<u32>::is_lock_free(),
             cfg!(any(
-                target_pointer_width = "32",
-                all(feature = "nightly", target_has_atomic = "32")
+                has_atomic_u32,
+                all(target_pointer_width = "32", has_atomic_usize)
             ))
         );
         assert_eq!(format!("{:?}", a), "Atomic(0)");
@@ -663,8 +643,8 @@ mod tests {
         assert_eq!(
             Atomic::<u64>::is_lock_free(),
             cfg!(any(
-                target_pointer_width = "64",
-                all(feature = "nightly", target_has_atomic = "64")
+                has_atomic_u64,
+                all(target_pointer_width = "64", has_atomic_usize)
             )) && mem::align_of::<u64>() == 8
         );
         assert_eq!(format!("{:?}", a), "Atomic(0)");
@@ -688,10 +668,7 @@ mod tests {
         let a = Atomic::new(0u128);
         assert_eq!(
             Atomic::<u128>::is_lock_free(),
-            cfg!(any(
-                target_pointer_width = "128",
-                all(feature = "nightly", target_has_atomic = "128")
-            ))
+            cfg!(all(target_pointer_width = "128", has_atomic_usize))
         );
         assert_eq!(format!("{:?}", a), "Atomic(0)");
         assert_eq!(a.load(SeqCst), 0);
@@ -712,7 +689,7 @@ mod tests {
     #[test]
     fn atomic_usize() {
         let a = Atomic::new(0usize);
-        assert!(Atomic::<usize>::is_lock_free());
+        assert_eq!(Atomic::<usize>::is_lock_free(), cfg!(has_atomic_usize));
         assert_eq!(format!("{:?}", a), "Atomic(0)");
         assert_eq!(a.load(SeqCst), 0);
         a.store(1, SeqCst);
@@ -772,7 +749,10 @@ mod tests {
         let a = Atomic::default();
         assert_eq!(
             Atomic::<Quux>::is_lock_free(),
-            cfg!(any(feature = "nightly", target_pointer_width = "32"))
+            cfg!(any(
+                has_atomic_u32,
+                all(target_pointer_width = "4", has_atomic_usize)
+            ))
         );
         assert_eq!(format!("{:?}", a), "Atomic(Quux(0))");
         assert_eq!(a.load(SeqCst), Quux(0));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -392,13 +392,7 @@ mod tests {
     #[test]
     fn atomic_bool() {
         let a = Atomic::new(false);
-        assert_eq!(
-            Atomic::<bool>::is_lock_free(),
-            cfg!(any(
-                has_atomic_u8,
-                all(target_pointer_width = "8", has_atomic_usize)
-            ))
-        );
+        assert_eq!(Atomic::<bool>::is_lock_free(), cfg!(has_atomic_u8),);
         assert_eq!(format!("{:?}", a), "Atomic(false)");
         assert_eq!(a.load(SeqCst), false);
         a.store(true, SeqCst);
@@ -414,13 +408,7 @@ mod tests {
     #[test]
     fn atomic_i8() {
         let a = Atomic::new(0i8);
-        assert_eq!(
-            Atomic::<i8>::is_lock_free(),
-            cfg!(any(
-                has_atomic_u8,
-                all(target_pointer_width = "8", has_atomic_usize)
-            ))
-        );
+        assert_eq!(Atomic::<i8>::is_lock_free(), cfg!(has_atomic_u8));
         assert_eq!(format!("{:?}", a), "Atomic(0)");
         assert_eq!(a.load(SeqCst), 0);
         a.store(1, SeqCst);
@@ -441,13 +429,7 @@ mod tests {
     #[test]
     fn atomic_i16() {
         let a = Atomic::new(0i16);
-        assert_eq!(
-            Atomic::<i16>::is_lock_free(),
-            cfg!(any(
-                has_atomic_u16,
-                all(target_pointer_width = "16", has_atomic_usize)
-            ))
-        );
+        assert_eq!(Atomic::<i16>::is_lock_free(), cfg!(has_atomic_u16));
         assert_eq!(format!("{:?}", a), "Atomic(0)");
         assert_eq!(a.load(SeqCst), 0);
         a.store(1, SeqCst);
@@ -467,13 +449,7 @@ mod tests {
     #[test]
     fn atomic_i32() {
         let a = Atomic::new(0i32);
-        assert_eq!(
-            Atomic::<i32>::is_lock_free(),
-            cfg!(any(
-                has_atomic_u32,
-                all(target_pointer_width = "32", has_atomic_usize)
-            ))
-        );
+        assert_eq!(Atomic::<i32>::is_lock_free(), cfg!(has_atomic_u32));
         assert_eq!(format!("{:?}", a), "Atomic(0)");
         assert_eq!(a.load(SeqCst), 0);
         a.store(1, SeqCst);
@@ -495,10 +471,7 @@ mod tests {
         let a = Atomic::new(0i64);
         assert_eq!(
             Atomic::<i64>::is_lock_free(),
-            cfg!(any(
-                has_atomic_u64,
-                all(target_pointer_width = "64", has_atomic_usize)
-            )) && mem::align_of::<i64>() == 8
+            cfg!(has_atomic_u64) && mem::align_of::<i64>() == 8
         );
         assert_eq!(format!("{:?}", a), "Atomic(0)");
         assert_eq!(a.load(SeqCst), 0);
@@ -519,10 +492,7 @@ mod tests {
     #[test]
     fn atomic_i128() {
         let a = Atomic::new(0i128);
-        assert_eq!(
-            Atomic::<i128>::is_lock_free(),
-            cfg!(all(target_pointer_width = "128", has_atomic_usize))
-        );
+        assert_eq!(Atomic::<i128>::is_lock_free(), cfg!(has_atomic_u128));
         assert_eq!(format!("{:?}", a), "Atomic(0)");
         assert_eq!(a.load(SeqCst), 0);
         a.store(1, SeqCst);
@@ -542,7 +512,6 @@ mod tests {
     #[test]
     fn atomic_isize() {
         let a = Atomic::new(0isize);
-        assert_eq!(Atomic::<isize>::is_lock_free(), cfg!(has_atomic_usize));
         assert_eq!(format!("{:?}", a), "Atomic(0)");
         assert_eq!(a.load(SeqCst), 0);
         a.store(1, SeqCst);
@@ -562,13 +531,7 @@ mod tests {
     #[test]
     fn atomic_u8() {
         let a = Atomic::new(0u8);
-        assert_eq!(
-            Atomic::<u8>::is_lock_free(),
-            cfg!(any(
-                has_atomic_u8,
-                all(target_pointer_width = "8", has_atomic_usize)
-            ))
-        );
+        assert_eq!(Atomic::<u8>::is_lock_free(), cfg!(has_atomic_u8));
         assert_eq!(format!("{:?}", a), "Atomic(0)");
         assert_eq!(a.load(SeqCst), 0);
         a.store(1, SeqCst);
@@ -588,13 +551,7 @@ mod tests {
     #[test]
     fn atomic_u16() {
         let a = Atomic::new(0u16);
-        assert_eq!(
-            Atomic::<u16>::is_lock_free(),
-            cfg!(any(
-                has_atomic_u16,
-                all(target_pointer_width = "16", has_atomic_usize)
-            ))
-        );
+        assert_eq!(Atomic::<u16>::is_lock_free(), cfg!(has_atomic_u16));
         assert_eq!(format!("{:?}", a), "Atomic(0)");
         assert_eq!(a.load(SeqCst), 0);
         a.store(1, SeqCst);
@@ -614,13 +571,7 @@ mod tests {
     #[test]
     fn atomic_u32() {
         let a = Atomic::new(0u32);
-        assert_eq!(
-            Atomic::<u32>::is_lock_free(),
-            cfg!(any(
-                has_atomic_u32,
-                all(target_pointer_width = "32", has_atomic_usize)
-            ))
-        );
+        assert_eq!(Atomic::<u32>::is_lock_free(), cfg!(has_atomic_u32));
         assert_eq!(format!("{:?}", a), "Atomic(0)");
         assert_eq!(a.load(SeqCst), 0);
         a.store(1, SeqCst);
@@ -642,10 +593,7 @@ mod tests {
         let a = Atomic::new(0u64);
         assert_eq!(
             Atomic::<u64>::is_lock_free(),
-            cfg!(any(
-                has_atomic_u64,
-                all(target_pointer_width = "64", has_atomic_usize)
-            )) && mem::align_of::<u64>() == 8
+            cfg!(has_atomic_u64) && mem::align_of::<u64>() == 8
         );
         assert_eq!(format!("{:?}", a), "Atomic(0)");
         assert_eq!(a.load(SeqCst), 0);
@@ -666,10 +614,7 @@ mod tests {
     #[test]
     fn atomic_u128() {
         let a = Atomic::new(0u128);
-        assert_eq!(
-            Atomic::<u128>::is_lock_free(),
-            cfg!(all(target_pointer_width = "128", has_atomic_usize))
-        );
+        assert_eq!(Atomic::<u128>::is_lock_free(), cfg!(has_atomic_u128));
         assert_eq!(format!("{:?}", a), "Atomic(0)");
         assert_eq!(a.load(SeqCst), 0);
         a.store(1, SeqCst);
@@ -689,7 +634,6 @@ mod tests {
     #[test]
     fn atomic_usize() {
         let a = Atomic::new(0usize);
-        assert_eq!(Atomic::<usize>::is_lock_free(), cfg!(has_atomic_usize));
         assert_eq!(format!("{:?}", a), "Atomic(0)");
         assert_eq!(a.load(SeqCst), 0);
         a.store(1, SeqCst);
@@ -747,13 +691,7 @@ mod tests {
     #[test]
     fn atomic_quxx() {
         let a = Atomic::default();
-        assert_eq!(
-            Atomic::<Quux>::is_lock_free(),
-            cfg!(any(
-                has_atomic_u32,
-                all(target_pointer_width = "4", has_atomic_usize)
-            ))
-        );
+        assert_eq!(Atomic::<Quux>::is_lock_free(), cfg!(has_atomic_u32));
         assert_eq!(format!("{:?}", a), "Atomic(Quux(0))");
         assert_eq!(a.load(SeqCst), Quux(0));
         a.store(Quux(1), SeqCst);

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -39,6 +39,12 @@ macro_rules! match_atomic {
 
                 $impl
             }
+            #[cfg(has_atomic_u128)]
+            16 if mem::align_of::<$type>() >= 16 => {
+                type $atomic = core::sync::atomic::AtomicU128;
+
+                $impl
+            }
             _ => $fallback_impl,
         }
     };
@@ -71,6 +77,12 @@ macro_rules! match_signed_atomic {
 
                 $impl
             }
+            #[cfg(has_atomic_u128)]
+            16 if mem::align_of::<$type>() >= 16 => {
+                type $atomic = core::sync::atomic::AtomicI128;
+
+                $impl
+            }
             _ => $fallback_impl,
         }
     };
@@ -85,6 +97,7 @@ pub const fn atomic_is_lock_free<T>() -> bool {
         | (cfg!(has_atomic_u16) & (size == 2) & (align >= 2))
         | (cfg!(has_atomic_u32) & (size == 4) & (align >= 4))
         | (cfg!(has_atomic_u64) & (size == 8) & (align >= 8))
+        | (cfg!(has_atomic_u128) & (size == 16) & (align >= 16))
 }
 
 #[inline]

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -12,139 +12,127 @@ use core::ops;
 use core::sync::atomic::Ordering;
 use fallback;
 
-#[cfg(all(feature = "nightly", target_has_atomic = "8"))]
-use core::sync::atomic::{ AtomicI8, AtomicU8 };
-#[cfg(all(feature = "nightly", target_has_atomic = "16"))]
-use core::sync::atomic::{ AtomicI16, AtomicU16 };
-#[cfg(all(feature = "nightly", target_has_atomic = "32"))]
-use core::sync::atomic::{ AtomicI32, AtomicU32 };
-#[cfg(all(feature = "nightly", target_has_atomic = "64"))]
-use core::sync::atomic::{ AtomicI64, AtomicU64 };
-
-#[cfg(not(feature = "nightly"))]
-use core::sync::atomic::AtomicUsize;
-#[cfg(not(feature = "nightly"))]
 const SIZEOF_USIZE: usize = mem::size_of::<usize>();
-#[cfg(not(feature = "nightly"))]
 const ALIGNOF_USIZE: usize = mem::align_of::<usize>();
 
-#[cfg(feature = "nightly")]
-#[inline]
-pub const fn atomic_is_lock_free<T>() -> bool {
-    let size = mem::size_of::<T>();
-    // FIXME: switch to … && … && … once that operator is supported in const functions
-    (1 == size.count_ones()) & (8 >= size) & (mem::align_of::<T>() >= size)
+macro_rules! match_atomic {
+    ($type:ident, $atomic:ident, $impl:expr, $fallback_impl:expr) => {
+        match mem::size_of::<$type>() {
+            #[cfg(has_atomic_u8)]
+            1 if mem::align_of::<$type>() >= 1 => {
+                type $atomic = core::sync::atomic::AtomicU8;
+
+                $impl
+            }
+            #[cfg(has_atomic_u16)]
+            2 if mem::align_of::<$type>() >= 2 => {
+                type $atomic = core::sync::atomic::AtomicU16;
+
+                $impl
+            }
+            #[cfg(has_atomic_u32)]
+            4 if mem::align_of::<$type>() >= 4 => {
+                type $atomic = core::sync::atomic::AtomicU32;
+
+                $impl
+            }
+            #[cfg(has_atomic_u64)]
+            8 if mem::align_of::<$type>() >= 8 => {
+                type $atomic = core::sync::atomic::AtomicU64;
+
+                $impl
+            }
+            #[cfg(has_atomic_usize)]
+            SIZEOF_USIZE if mem::align_of::<$type>() >= ALIGNOF_USIZE => {
+                type $atomic = core::sync::atomic::AtomicUsize;
+
+                $impl
+            }
+            _ => $fallback_impl,
+        }
+    };
 }
 
-#[cfg(not(feature = "nightly"))]
+const SIZEOF_ISIZE: usize = mem::size_of::<isize>();
+const ALIGNOF_ISIZE: usize = mem::align_of::<isize>();
+
+macro_rules! match_signed_atomic {
+    ($type:ident, $atomic:ident, $impl:expr, $fallback_impl:expr) => {
+        match mem::size_of::<$type>() {
+            #[cfg(has_atomic_i8)]
+            1 if mem::align_of::<$type>() >= 1 => {
+                type $atomic = core::sync::atomic::AtomicI8;
+
+                $impl
+            }
+            #[cfg(has_atomic_i16)]
+            2 if mem::align_of::<$type>() >= 2 => {
+                type $atomic = core::sync::atomic::AtomicI16;
+
+                $impl
+            }
+            #[cfg(has_atomic_i32)]
+            4 if mem::align_of::<$type>() >= 4 => {
+                type $atomic = core::sync::atomic::AtomicI32;
+
+                $impl
+            }
+            #[cfg(has_atomic_i64)]
+            8 if mem::align_of::<$type>() >= 8 => {
+                type $atomic = core::sync::atomic::AtomicI64;
+
+                $impl
+            }
+            #[cfg(has_atomic_isize)]
+            SIZEOF_ISIZE if mem::align_of::<$type>() >= ALIGNOF_ISIZE => {
+                type $atomic = core::sync::atomic::AtomicIsize;
+
+                $impl
+            }
+            _ => $fallback_impl,
+        }
+    };
+}
+
 #[inline]
-pub fn atomic_is_lock_free<T>() -> bool {
-    let size = mem::size_of::<T>();
-    1 == size.count_ones() && SIZEOF_USIZE >= size && mem::align_of::<T>() >= ALIGNOF_USIZE
+pub const fn atomic_is_lock_free<T>() -> bool {
+    (cfg!(has_atomic_u8) & (mem::size_of::<T>() == 1) & (mem::align_of::<T>() >= 1))
+        | (cfg!(has_atomic_u16) & (mem::size_of::<T>() == 2) & (mem::align_of::<T>() >= 2))
+        | (cfg!(has_atomic_u32) & (mem::size_of::<T>() == 4) & (mem::align_of::<T>() >= 4))
+        | (cfg!(has_atomic_u64) & (mem::size_of::<T>() == 8) & (mem::align_of::<T>() >= 8))
+        | (cfg!(has_atomic_usize)
+            & (mem::size_of::<T>() == mem::size_of::<usize>())
+            & (mem::align_of::<T>() >= mem::align_of::<usize>()))
 }
 
 #[inline]
 pub unsafe fn atomic_load<T>(dst: *mut T, order: Ordering) -> T {
-    match mem::size_of::<T>() {
-        #[cfg(all(feature = "nightly", target_has_atomic = "8"))]
-        1 if mem::align_of::<T>() >= 1 =>
-        {
-            mem::transmute_copy(&(*(dst as *const AtomicU8)).load(order))
-        }
-        #[cfg(all(feature = "nightly", target_has_atomic = "16"))]
-        2 if mem::align_of::<T>() >= 2 =>
-        {
-            mem::transmute_copy(&(*(dst as *const AtomicU16)).load(order))
-        }
-        #[cfg(all(feature = "nightly", target_has_atomic = "32"))]
-        4 if mem::align_of::<T>() >= 4 =>
-        {
-            mem::transmute_copy(&(*(dst as *const AtomicU32)).load(order))
-        }
-        #[cfg(all(feature = "nightly", target_has_atomic = "64"))]
-        8 if mem::align_of::<T>() >= 8 =>
-        {
-            mem::transmute_copy(&(*(dst as *const AtomicU64)).load(order))
-        }
-        #[cfg(not(feature = "nightly"))]
-        SIZEOF_USIZE if mem::align_of::<T>() >= ALIGNOF_USIZE =>
-        {
-            mem::transmute_copy(&(*(dst as *const AtomicUsize)).load(order))
-        }
-        _ => fallback::atomic_load(dst),
-    }
+    match_atomic!(
+        T,
+        A,
+        mem::transmute_copy(&(*(dst as *const A)).load(order)),
+        fallback::atomic_load(dst)
+    )
 }
 
 #[inline]
 pub unsafe fn atomic_store<T>(dst: *mut T, val: T, order: Ordering) {
-    match mem::size_of::<T>() {
-        #[cfg(all(feature = "nightly", target_has_atomic = "8"))]
-        1 if mem::align_of::<T>() >= 1 =>
-        {
-            (*(dst as *const AtomicU8)).store(mem::transmute_copy(&val), order)
-        }
-        #[cfg(all(feature = "nightly", target_has_atomic = "16"))]
-        2 if mem::align_of::<T>() >= 2 =>
-        {
-            (*(dst as *const AtomicU16)).store(mem::transmute_copy(&val), order)
-        }
-        #[cfg(all(feature = "nightly", target_has_atomic = "32"))]
-        4 if mem::align_of::<T>() >= 4 =>
-        {
-            (*(dst as *const AtomicU32)).store(mem::transmute_copy(&val), order)
-        }
-        #[cfg(all(feature = "nightly", target_has_atomic = "64"))]
-        8 if mem::align_of::<T>() >= 8 =>
-        {
-            (*(dst as *const AtomicU64)).store(mem::transmute_copy(&val), order)
-        }
-        #[cfg(not(feature = "nightly"))]
-        SIZEOF_USIZE if mem::align_of::<T>() >= ALIGNOF_USIZE =>
-        {
-            (*(dst as *const AtomicUsize)).store(mem::transmute_copy(&val), order)
-        }
-        _ => fallback::atomic_store(dst, val),
-    }
+    match_atomic!(
+        T,
+        A,
+        (*(dst as *const A)).store(mem::transmute_copy(&val), order),
+        fallback::atomic_store(dst, val)
+    )
 }
 
 #[inline]
 pub unsafe fn atomic_swap<T>(dst: *mut T, val: T, order: Ordering) -> T {
-    match mem::size_of::<T>() {
-        #[cfg(all(feature = "nightly", target_has_atomic = "8"))]
-        1 if mem::align_of::<T>() >= 1 =>
-        {
-            mem::transmute_copy(&(*(dst as *const AtomicU8)).swap(mem::transmute_copy(&val), order))
-        }
-        #[cfg(all(feature = "nightly", target_has_atomic = "16"))]
-        2 if mem::align_of::<T>() >= 2 =>
-        {
-            mem::transmute_copy(
-                &(*(dst as *const AtomicU16)).swap(mem::transmute_copy(&val), order),
-            )
-        }
-        #[cfg(all(feature = "nightly", target_has_atomic = "32"))]
-        4 if mem::align_of::<T>() >= 4 =>
-        {
-            mem::transmute_copy(
-                &(*(dst as *const AtomicU32)).swap(mem::transmute_copy(&val), order),
-            )
-        }
-        #[cfg(all(feature = "nightly", target_has_atomic = "64"))]
-        8 if mem::align_of::<T>() >= 8 =>
-        {
-            mem::transmute_copy(
-                &(*(dst as *const AtomicU64)).swap(mem::transmute_copy(&val), order),
-            )
-        }
-        #[cfg(not(feature = "nightly"))]
-        SIZEOF_USIZE if mem::align_of::<T>() >= ALIGNOF_USIZE =>
-        {
-            mem::transmute_copy(
-                &(*(dst as *const AtomicUsize)).swap(mem::transmute_copy(&val), order),
-            )
-        }
-        _ => fallback::atomic_swap(dst, val),
-    }
+    match_atomic!(
+        T,
+        A,
+        mem::transmute_copy(&(*(dst as *const A)).swap(mem::transmute_copy(&val), order)),
+        fallback::atomic_swap(dst, val)
+    )
 }
 
 #[inline]
@@ -163,59 +151,17 @@ pub unsafe fn atomic_compare_exchange<T>(
     success: Ordering,
     failure: Ordering,
 ) -> Result<T, T> {
-    match mem::size_of::<T>() {
-        #[cfg(all(feature = "nightly", target_has_atomic = "8"))]
-        1 if mem::align_of::<T>() >= 1 =>
-        {
-            map_result((*(dst as *const AtomicU8)).compare_exchange(
-                mem::transmute_copy(&current),
-                mem::transmute_copy(&new),
-                success,
-                failure,
-            ))
-        }
-        #[cfg(all(feature = "nightly", target_has_atomic = "16"))]
-        2 if mem::align_of::<T>() >= 2 =>
-        {
-            map_result((*(dst as *const AtomicU16)).compare_exchange(
-                mem::transmute_copy(&current),
-                mem::transmute_copy(&new),
-                success,
-                failure,
-            ))
-        }
-        #[cfg(all(feature = "nightly", target_has_atomic = "32"))]
-        4 if mem::align_of::<T>() >= 4 =>
-        {
-            map_result((*(dst as *const AtomicU32)).compare_exchange(
-                mem::transmute_copy(&current),
-                mem::transmute_copy(&new),
-                success,
-                failure,
-            ))
-        }
-        #[cfg(all(feature = "nightly", target_has_atomic = "64"))]
-        8 if mem::align_of::<T>() >= 8 =>
-        {
-            map_result((*(dst as *const AtomicU64)).compare_exchange(
-                mem::transmute_copy(&current),
-                mem::transmute_copy(&new),
-                success,
-                failure,
-            ))
-        }
-        #[cfg(not(feature = "nightly"))]
-        SIZEOF_USIZE if mem::align_of::<T>() >= ALIGNOF_USIZE =>
-        {
-            map_result((*(dst as *const AtomicUsize)).compare_exchange(
-                mem::transmute_copy(&current),
-                mem::transmute_copy(&new),
-                success,
-                failure,
-            ))
-        }
-        _ => fallback::atomic_compare_exchange(dst, current, new),
-    }
+    match_atomic!(
+        T,
+        A,
+        map_result((*(dst as *const A)).compare_exchange(
+            mem::transmute_copy(&current),
+            mem::transmute_copy(&new),
+            success,
+            failure,
+        )),
+        fallback::atomic_compare_exchange(dst, current, new)
+    )
 }
 
 #[inline]
@@ -226,59 +172,17 @@ pub unsafe fn atomic_compare_exchange_weak<T>(
     success: Ordering,
     failure: Ordering,
 ) -> Result<T, T> {
-    match mem::size_of::<T>() {
-        #[cfg(all(feature = "nightly", target_has_atomic = "8"))]
-        1 if mem::align_of::<T>() >= 1 =>
-        {
-            map_result((*(dst as *const AtomicU8)).compare_exchange_weak(
-                mem::transmute_copy(&current),
-                mem::transmute_copy(&new),
-                success,
-                failure,
-            ))
-        }
-        #[cfg(all(feature = "nightly", target_has_atomic = "16"))]
-        2 if mem::align_of::<T>() >= 2 =>
-        {
-            map_result((*(dst as *const AtomicU16)).compare_exchange_weak(
-                mem::transmute_copy(&current),
-                mem::transmute_copy(&new),
-                success,
-                failure,
-            ))
-        }
-        #[cfg(all(feature = "nightly", target_has_atomic = "32"))]
-        4 if mem::align_of::<T>() >= 4 =>
-        {
-            map_result((*(dst as *const AtomicU32)).compare_exchange_weak(
-                mem::transmute_copy(&current),
-                mem::transmute_copy(&new),
-                success,
-                failure,
-            ))
-        }
-        #[cfg(all(feature = "nightly", target_has_atomic = "64"))]
-        8 if mem::align_of::<T>() >= 8 =>
-        {
-            map_result((*(dst as *const AtomicU64)).compare_exchange_weak(
-                mem::transmute_copy(&current),
-                mem::transmute_copy(&new),
-                success,
-                failure,
-            ))
-        }
-        #[cfg(not(feature = "nightly"))]
-        SIZEOF_USIZE if mem::align_of::<T>() >= ALIGNOF_USIZE =>
-        {
-            map_result((*(dst as *const AtomicUsize)).compare_exchange_weak(
-                mem::transmute_copy(&current),
-                mem::transmute_copy(&new),
-                success,
-                failure,
-            ))
-        }
-        _ => fallback::atomic_compare_exchange(dst, current, new),
-    }
+    match_atomic!(
+        T,
+        A,
+        map_result((*(dst as *const A)).compare_exchange_weak(
+            mem::transmute_copy(&current),
+            mem::transmute_copy(&new),
+            success,
+            failure,
+        )),
+        fallback::atomic_compare_exchange(dst, current, new)
+    )
 }
 
 #[inline]
@@ -286,44 +190,12 @@ pub unsafe fn atomic_add<T: Copy>(dst: *mut T, val: T, order: Ordering) -> T
 where
     Wrapping<T>: ops::Add<Output = Wrapping<T>>,
 {
-    match mem::size_of::<T>() {
-        #[cfg(all(feature = "nightly", target_has_atomic = "8"))]
-        1 if mem::align_of::<T>() >= 1 =>
-        {
-            mem::transmute_copy(
-                &(*(dst as *const AtomicU8)).fetch_add(mem::transmute_copy(&val), order),
-            )
-        }
-        #[cfg(all(feature = "nightly", target_has_atomic = "16"))]
-        2 if mem::align_of::<T>() >= 2 =>
-        {
-            mem::transmute_copy(
-                &(*(dst as *const AtomicU16)).fetch_add(mem::transmute_copy(&val), order),
-            )
-        }
-        #[cfg(all(feature = "nightly", target_has_atomic = "32"))]
-        4 if mem::align_of::<T>() >= 4 =>
-        {
-            mem::transmute_copy(
-                &(*(dst as *const AtomicU32)).fetch_add(mem::transmute_copy(&val), order),
-            )
-        }
-        #[cfg(all(feature = "nightly", target_has_atomic = "64"))]
-        8 if mem::align_of::<T>() >= 8 =>
-        {
-            mem::transmute_copy(
-                &(*(dst as *const AtomicU64)).fetch_add(mem::transmute_copy(&val), order),
-            )
-        }
-        #[cfg(not(feature = "nightly"))]
-        SIZEOF_USIZE if mem::align_of::<T>() >= ALIGNOF_USIZE =>
-        {
-            mem::transmute_copy(
-                &(*(dst as *const AtomicUsize)).fetch_add(mem::transmute_copy(&val), order),
-            )
-        }
-        _ => fallback::atomic_add(dst, val),
-    }
+    match_atomic!(
+        T,
+        A,
+        mem::transmute_copy(&(*(dst as *const A)).fetch_add(mem::transmute_copy(&val), order),),
+        fallback::atomic_add(dst, val)
+    )
 }
 
 #[inline]
@@ -331,44 +203,12 @@ pub unsafe fn atomic_sub<T: Copy>(dst: *mut T, val: T, order: Ordering) -> T
 where
     Wrapping<T>: ops::Sub<Output = Wrapping<T>>,
 {
-    match mem::size_of::<T>() {
-        #[cfg(all(feature = "nightly", target_has_atomic = "8"))]
-        1 if mem::align_of::<T>() >= 1 =>
-        {
-            mem::transmute_copy(
-                &(*(dst as *const AtomicU8)).fetch_sub(mem::transmute_copy(&val), order),
-            )
-        }
-        #[cfg(all(feature = "nightly", target_has_atomic = "16"))]
-        2 if mem::align_of::<T>() >= 2 =>
-        {
-            mem::transmute_copy(
-                &(*(dst as *const AtomicU16)).fetch_sub(mem::transmute_copy(&val), order),
-            )
-        }
-        #[cfg(all(feature = "nightly", target_has_atomic = "32"))]
-        4 if mem::align_of::<T>() >= 4 =>
-        {
-            mem::transmute_copy(
-                &(*(dst as *const AtomicU32)).fetch_sub(mem::transmute_copy(&val), order),
-            )
-        }
-        #[cfg(all(feature = "nightly", target_has_atomic = "64"))]
-        8 if mem::align_of::<T>() >= 8 =>
-        {
-            mem::transmute_copy(
-                &(*(dst as *const AtomicU64)).fetch_sub(mem::transmute_copy(&val), order),
-            )
-        }
-        #[cfg(not(feature = "nightly"))]
-        SIZEOF_USIZE if mem::align_of::<T>() >= ALIGNOF_USIZE =>
-        {
-            mem::transmute_copy(
-                &(*(dst as *const AtomicUsize)).fetch_sub(mem::transmute_copy(&val), order),
-            )
-        }
-        _ => fallback::atomic_sub(dst, val),
-    }
+    match_atomic!(
+        T,
+        A,
+        mem::transmute_copy(&(*(dst as *const A)).fetch_sub(mem::transmute_copy(&val), order),),
+        fallback::atomic_sub(dst, val)
+    )
 }
 
 #[inline]
@@ -377,44 +217,12 @@ pub unsafe fn atomic_and<T: Copy + ops::BitAnd<Output = T>>(
     val: T,
     order: Ordering,
 ) -> T {
-    match mem::size_of::<T>() {
-        #[cfg(all(feature = "nightly", target_has_atomic = "8"))]
-        1 if mem::align_of::<T>() >= 1 =>
-        {
-            mem::transmute_copy(
-                &(*(dst as *const AtomicU8)).fetch_and(mem::transmute_copy(&val), order),
-            )
-        }
-        #[cfg(all(feature = "nightly", target_has_atomic = "16"))]
-        2 if mem::align_of::<T>() >= 2 =>
-        {
-            mem::transmute_copy(
-                &(*(dst as *const AtomicU16)).fetch_and(mem::transmute_copy(&val), order),
-            )
-        }
-        #[cfg(all(feature = "nightly", target_has_atomic = "32"))]
-        4 if mem::align_of::<T>() >= 4 =>
-        {
-            mem::transmute_copy(
-                &(*(dst as *const AtomicU32)).fetch_and(mem::transmute_copy(&val), order),
-            )
-        }
-        #[cfg(all(feature = "nightly", target_has_atomic = "64"))]
-        8 if mem::align_of::<T>() >= 8 =>
-        {
-            mem::transmute_copy(
-                &(*(dst as *const AtomicU64)).fetch_and(mem::transmute_copy(&val), order),
-            )
-        }
-        #[cfg(not(feature = "nightly"))]
-        SIZEOF_USIZE if mem::align_of::<T>() >= ALIGNOF_USIZE =>
-        {
-            mem::transmute_copy(
-                &(*(dst as *const AtomicUsize)).fetch_and(mem::transmute_copy(&val), order),
-            )
-        }
-        _ => fallback::atomic_and(dst, val),
-    }
+    match_atomic!(
+        T,
+        A,
+        mem::transmute_copy(&(*(dst as *const A)).fetch_and(mem::transmute_copy(&val), order),),
+        fallback::atomic_and(dst, val)
+    )
 }
 
 #[inline]
@@ -423,44 +231,12 @@ pub unsafe fn atomic_or<T: Copy + ops::BitOr<Output = T>>(
     val: T,
     order: Ordering,
 ) -> T {
-    match mem::size_of::<T>() {
-        #[cfg(all(feature = "nightly", target_has_atomic = "8"))]
-        1 if mem::align_of::<T>() >= 1 =>
-        {
-            mem::transmute_copy(
-                &(*(dst as *const AtomicU8)).fetch_or(mem::transmute_copy(&val), order),
-            )
-        }
-        #[cfg(all(feature = "nightly", target_has_atomic = "16"))]
-        2 if mem::align_of::<T>() >= 2 =>
-        {
-            mem::transmute_copy(
-                &(*(dst as *const AtomicU16)).fetch_or(mem::transmute_copy(&val), order),
-            )
-        }
-        #[cfg(all(feature = "nightly", target_has_atomic = "32"))]
-        4 if mem::align_of::<T>() >= 4 =>
-        {
-            mem::transmute_copy(
-                &(*(dst as *const AtomicU32)).fetch_or(mem::transmute_copy(&val), order),
-            )
-        }
-        #[cfg(all(feature = "nightly", target_has_atomic = "64"))]
-        8 if mem::align_of::<T>() >= 8 =>
-        {
-            mem::transmute_copy(
-                &(*(dst as *const AtomicU64)).fetch_or(mem::transmute_copy(&val), order),
-            )
-        }
-        #[cfg(not(feature = "nightly"))]
-        SIZEOF_USIZE if mem::align_of::<T>() >= ALIGNOF_USIZE =>
-        {
-            mem::transmute_copy(
-                &(*(dst as *const AtomicUsize)).fetch_or(mem::transmute_copy(&val), order),
-            )
-        }
-        _ => fallback::atomic_or(dst, val),
-    }
+    match_atomic!(
+        T,
+        A,
+        mem::transmute_copy(&(*(dst as *const A)).fetch_or(mem::transmute_copy(&val), order),),
+        fallback::atomic_or(dst, val)
+    )
 }
 
 #[inline]
@@ -469,198 +245,62 @@ pub unsafe fn atomic_xor<T: Copy + ops::BitXor<Output = T>>(
     val: T,
     order: Ordering,
 ) -> T {
-    match mem::size_of::<T>() {
-        #[cfg(all(feature = "nightly", target_has_atomic = "8"))]
-        1 if mem::align_of::<T>() >= 1 =>
-        {
-            mem::transmute_copy(
-                &(*(dst as *const AtomicU8)).fetch_xor(mem::transmute_copy(&val), order),
-            )
-        }
-        #[cfg(all(feature = "nightly", target_has_atomic = "16"))]
-        2 if mem::align_of::<T>() >= 2 =>
-        {
-            mem::transmute_copy(
-                &(*(dst as *const AtomicU16)).fetch_xor(mem::transmute_copy(&val), order),
-            )
-        }
-        #[cfg(all(feature = "nightly", target_has_atomic = "32"))]
-        4 if mem::align_of::<T>() >= 4 =>
-        {
-            mem::transmute_copy(
-                &(*(dst as *const AtomicU32)).fetch_xor(mem::transmute_copy(&val), order),
-            )
-        }
-        #[cfg(all(feature = "nightly", target_has_atomic = "64"))]
-        8 if mem::align_of::<T>() >= 8 =>
-        {
-            mem::transmute_copy(
-                &(*(dst as *const AtomicU64)).fetch_xor(mem::transmute_copy(&val), order),
-            )
-        }
-        #[cfg(not(feature = "nightly"))]
-        SIZEOF_USIZE if mem::align_of::<T>() >= ALIGNOF_USIZE =>
-        {
-            mem::transmute_copy(
-                &(*(dst as *const AtomicUsize)).fetch_xor(mem::transmute_copy(&val), order),
-            )
-        }
-        _ => fallback::atomic_xor(dst, val),
-    }
+    match_atomic!(
+        T,
+        A,
+        mem::transmute_copy(&(*(dst as *const A)).fetch_xor(mem::transmute_copy(&val), order),),
+        fallback::atomic_xor(dst, val)
+    )
 }
 
 #[inline]
 pub unsafe fn atomic_min<T: Copy + cmp::Ord>(dst: *mut T, val: T, order: Ordering) -> T {
-    // Silence warning, fetch_min is not stable yet
-    #[cfg(not(feature = "nightly"))]
-    let _ = order;
-
-    match mem::size_of::<T>() {
-        #[cfg(all(feature = "nightly", target_has_atomic = "8"))]
-        1 if mem::align_of::<T>() >= 1 =>
-        {
-            mem::transmute_copy(
-                &(*(dst as *const AtomicI8)).fetch_min(mem::transmute_copy(&val), order),
-            )
-        }
-        #[cfg(all(feature = "nightly", target_has_atomic = "16"))]
-        2 if mem::align_of::<T>() >= 2 =>
-        {
-            mem::transmute_copy(
-                &(*(dst as *const AtomicI16)).fetch_min(mem::transmute_copy(&val), order),
-            )
-        }
-        #[cfg(all(feature = "nightly", target_has_atomic = "32"))]
-        4 if mem::align_of::<T>() >= 4 =>
-        {
-            mem::transmute_copy(
-                &(*(dst as *const AtomicI32)).fetch_min(mem::transmute_copy(&val), order),
-            )
-        }
-        #[cfg(all(feature = "nightly", target_has_atomic = "64"))]
-        8 if mem::align_of::<T>() >= 8 =>
-        {
-            mem::transmute_copy(
-                &(*(dst as *const AtomicI64)).fetch_min(mem::transmute_copy(&val), order),
-            )
-        }
-        _ => fallback::atomic_min(dst, val),
-    }
+    #[cfg(has_fetch_min)]
+    return match_signed_atomic!(
+        T,
+        A,
+        mem::transmute_copy(&(*(dst as *const A)).fetch_min(mem::transmute_copy(&val), order),),
+        fallback::atomic_min(dst, val)
+    );
+    #[cfg(not(has_fetch_min))]
+    return fallback::atomic_min(dst, val);
 }
 
 #[inline]
 pub unsafe fn atomic_max<T: Copy + cmp::Ord>(dst: *mut T, val: T, order: Ordering) -> T {
-    // Silence warning, fetch_min is not stable yet
-    #[cfg(not(feature = "nightly"))]
-    let _ = order;
-
-    match mem::size_of::<T>() {
-        #[cfg(all(feature = "nightly", target_has_atomic = "8"))]
-        1 if mem::align_of::<T>() >= 1 =>
-        {
-            mem::transmute_copy(
-                &(*(dst as *const AtomicI8)).fetch_max(mem::transmute_copy(&val), order),
-            )
-        }
-        #[cfg(all(feature = "nightly", target_has_atomic = "16"))]
-        2 if mem::align_of::<T>() >= 2 =>
-        {
-            mem::transmute_copy(
-                &(*(dst as *const AtomicI16)).fetch_max(mem::transmute_copy(&val), order),
-            )
-        }
-        #[cfg(all(feature = "nightly", target_has_atomic = "32"))]
-        4 if mem::align_of::<T>() >= 4 =>
-        {
-            mem::transmute_copy(
-                &(*(dst as *const AtomicI32)).fetch_max(mem::transmute_copy(&val), order),
-            )
-        }
-        #[cfg(all(feature = "nightly", target_has_atomic = "64"))]
-        8 if mem::align_of::<T>() >= 8 =>
-        {
-            mem::transmute_copy(
-                &(*(dst as *const AtomicI64)).fetch_max(mem::transmute_copy(&val), order),
-            )
-        }
-        _ => fallback::atomic_max(dst, val),
-    }
+    #[cfg(has_fetch_min)]
+    return match_signed_atomic!(
+        T,
+        A,
+        mem::transmute_copy(&(*(dst as *const A)).fetch_max(mem::transmute_copy(&val), order),),
+        fallback::atomic_max(dst, val)
+    );
+    #[cfg(not(has_fetch_min))]
+    return fallback::atomic_max(dst, val);
 }
 
 #[inline]
 pub unsafe fn atomic_umin<T: Copy + cmp::Ord>(dst: *mut T, val: T, order: Ordering) -> T {
-    // Silence warning, fetch_min is not stable yet
-    #[cfg(not(feature = "nightly"))]
-    let _ = order;
-
-    match mem::size_of::<T>() {
-        #[cfg(all(feature = "nightly", target_has_atomic = "8"))]
-        1 if mem::align_of::<T>() >= 1 =>
-        {
-            mem::transmute_copy(
-                &(*(dst as *const AtomicU8)).fetch_min(mem::transmute_copy(&val), order),
-            )
-        }
-        #[cfg(all(feature = "nightly", target_has_atomic = "16"))]
-        2 if mem::align_of::<T>() >= 2 =>
-        {
-            mem::transmute_copy(
-                &(*(dst as *const AtomicU16)).fetch_min(mem::transmute_copy(&val), order),
-            )
-        }
-        #[cfg(all(feature = "nightly", target_has_atomic = "32"))]
-        4 if mem::align_of::<T>() >= 4 =>
-        {
-            mem::transmute_copy(
-                &(*(dst as *const AtomicU32)).fetch_min(mem::transmute_copy(&val), order),
-            )
-        }
-        #[cfg(all(feature = "nightly", target_has_atomic = "64"))]
-        8 if mem::align_of::<T>() >= 8 =>
-        {
-            mem::transmute_copy(
-                &(*(dst as *const AtomicU64)).fetch_min(mem::transmute_copy(&val), order),
-            )
-        }
-        _ => fallback::atomic_min(dst, val),
-    }
+    #[cfg(has_fetch_min)]
+    return match_atomic!(
+        T,
+        A,
+        mem::transmute_copy(&(*(dst as *const A)).fetch_min(mem::transmute_copy(&val), order),),
+        fallback::atomic_min(dst, val)
+    );
+    #[cfg(not(has_fetch_min))]
+    return fallback::atomic_min(dst, val);
 }
 
 #[inline]
 pub unsafe fn atomic_umax<T: Copy + cmp::Ord>(dst: *mut T, val: T, order: Ordering) -> T {
-    // Silence warning, fetch_min is not stable yet
-    #[cfg(not(feature = "nightly"))]
-    let _ = order;
-
-    match mem::size_of::<T>() {
-        #[cfg(all(feature = "nightly", target_has_atomic = "8"))]
-        1 if mem::align_of::<T>() >= 1 =>
-        {
-            mem::transmute_copy(
-                &(*(dst as *const AtomicU8)).fetch_max(mem::transmute_copy(&val), order),
-            )
-        }
-        #[cfg(all(feature = "nightly", target_has_atomic = "16"))]
-        2 if mem::align_of::<T>() >= 2 =>
-        {
-            mem::transmute_copy(
-                &(*(dst as *const AtomicU16)).fetch_max(mem::transmute_copy(&val), order),
-            )
-        }
-        #[cfg(all(feature = "nightly", target_has_atomic = "32"))]
-        4 if mem::align_of::<T>() >= 4 =>
-        {
-            mem::transmute_copy(
-                &(*(dst as *const AtomicU32)).fetch_max(mem::transmute_copy(&val), order),
-            )
-        }
-        #[cfg(all(feature = "nightly", target_has_atomic = "64"))]
-        8 if mem::align_of::<T>() >= 8 =>
-        {
-            mem::transmute_copy(
-                &(*(dst as *const AtomicU64)).fetch_max(mem::transmute_copy(&val), order),
-            )
-        }
-        _ => fallback::atomic_max(dst, val),
-    }
+    #[cfg(has_fetch_min)]
+    return match_atomic!(
+        T,
+        A,
+        mem::transmute_copy(&(*(dst as *const A)).fetch_max(mem::transmute_copy(&val), order),),
+        fallback::atomic_max(dst, val)
+    );
+    #[cfg(not(has_fetch_min))]
+    fallback::atomic_max(dst, val)
 }

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -12,9 +12,6 @@ use core::ops;
 use core::sync::atomic::Ordering;
 use fallback;
 
-const SIZEOF_USIZE: usize = mem::size_of::<usize>();
-const ALIGNOF_USIZE: usize = mem::align_of::<usize>();
-
 macro_rules! match_atomic {
     ($type:ident, $atomic:ident, $impl:expr, $fallback_impl:expr) => {
         match mem::size_of::<$type>() {
@@ -42,19 +39,10 @@ macro_rules! match_atomic {
 
                 $impl
             }
-            #[cfg(has_atomic_usize)]
-            SIZEOF_USIZE if mem::align_of::<$type>() >= ALIGNOF_USIZE => {
-                type $atomic = core::sync::atomic::AtomicUsize;
-
-                $impl
-            }
             _ => $fallback_impl,
         }
     };
 }
-
-const SIZEOF_ISIZE: usize = mem::size_of::<isize>();
-const ALIGNOF_ISIZE: usize = mem::align_of::<isize>();
 
 macro_rules! match_signed_atomic {
     ($type:ident, $atomic:ident, $impl:expr, $fallback_impl:expr) => {
@@ -83,12 +71,6 @@ macro_rules! match_signed_atomic {
 
                 $impl
             }
-            #[cfg(has_atomic_isize)]
-            SIZEOF_ISIZE if mem::align_of::<$type>() >= ALIGNOF_ISIZE => {
-                type $atomic = core::sync::atomic::AtomicIsize;
-
-                $impl
-            }
             _ => $fallback_impl,
         }
     };
@@ -103,7 +85,6 @@ pub const fn atomic_is_lock_free<T>() -> bool {
         | (cfg!(has_atomic_u16) & (size == 2) & (align >= 2))
         | (cfg!(has_atomic_u32) & (size == 4) & (align >= 4))
         | (cfg!(has_atomic_u64) & (size == 8) & (align >= 8))
-        | (cfg!(has_atomic_usize) & (size == SIZEOF_USIZE) & (align >= ALIGNOF_USIZE))
 }
 
 #[inline]


### PR DESCRIPTION
Instead of using unstable features, this detects the availability of the various atomic types using the autocfg crate by dynamically compiling code snippets via the build script.

This still raises the MSRV however as const functions `Atomic::new` and `Atomic::is_lock_free` cannot be defined below Rust 1.31.0.

Fixes #14 