### PR TITLE
Remove mentions of "nightly"

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,13 +26,6 @@ and this to your crate root:
 extern crate atomic;
 ```
 
-To enable nightly-only features, add this to your `Cargo.toml` instead:
-
-```toml
-[dependencies]
-atomic = {version = "0.5", features = ["nightly"]}
-```
-
 ## License
 
 Licensed under either of

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,8 +27,8 @@
 //! atomically-reference-counted shared pointer).
 //!
 //! Most atomic types may be stored in static variables, initialized using
-//! the `const fn` constructors (only available on nightly). Atomic statics
-//! are often used for lazy global initialization.
+//! the `const fn` constructors. Atomic statics are often used for lazy global
+//! initialization.
 
 #![warn(missing_docs)]
 #![warn(rust_2018_idioms)]


### PR DESCRIPTION
The nightly feature was removed in 0.5.0, hence remove its mentions.